### PR TITLE
fixed the demo program so the trace will terminate

### DIFF
--- a/Jaeger.Tutorial.AkkaApp/PingActor.cs
+++ b/Jaeger.Tutorial.AkkaApp/PingActor.cs
@@ -19,9 +19,7 @@ namespace Jaeger.Tutorial.AkkaApp
             Receive<string>(str =>
             {
                 Console.WriteLine($"{str} ");
-                IActorRef sender = Sender;
-                Thread.Sleep(10);
-                Sender.Tell("Hello");
+                // let the request-response operation terminate here
             });
         }
     }

--- a/Jaeger.Tutorial.AkkaApp/Program.cs
+++ b/Jaeger.Tutorial.AkkaApp/Program.cs
@@ -17,13 +17,13 @@ namespace Jaeger.Tutorial.AkkaApp
 
 
             pinger.Tell(ponger);
-            /*
+            
             system
                 .Scheduler
-                .ScheduleTellOnce(TimeSpan.FromSeconds(0),
-                //TimeSpan.FromSeconds(1),
+                .ScheduleTellRepeatedly(TimeSpan.FromSeconds(0),
+                TimeSpan.FromSeconds(1),
                 pinger, ponger, ActorRefs.NoSender);
-            */
+            
 
             Console.ReadLine();
         }


### PR DESCRIPTION
So I figured out why the traces produced by this program originally wouldn't render in Jaeger: due to the way this demo was originally constructed, the entire program was working on one perpetually massive trace consisting of thousands of spans per second. 

Essentially, the trace this demo produced was too big to be rendered by the Jaeger UI, but moreover - this isn't what a "real-world" trace would look like typically.

The way Phobos' actor message correlation works is as follows:

![phobos-actor-trace-correlation](https://user-images.githubusercontent.com/326939/52180461-f54f0c00-27ab-11e9-8ff6-279ae897e1ec.png)

The trace stops when actors stop producing new messages in response to ones they've previously received. So the example above will produced a distributed trace that looks like this:

![phobos-actor-trace-correlation-output](https://user-images.githubusercontent.com/326939/52180540-2da31a00-27ad-11e9-8508-724f4bbdf76f.png)

In this PR I've adjusted the sample some so rather than producing one giant, infinite trace it produces lots of small ones based on the interaction between the ping -> pong actors. Here's a sample:

![image](https://user-images.githubusercontent.com/326939/52180580-d0f42f00-27ad-11e9-9324-13add1be1472.png)

![image](https://user-images.githubusercontent.com/326939/52180586-e2d5d200-27ad-11e9-8f20-38c4a781e79b.png)

Theoretically, you could break up these giant traces without changing the way actors interact by using the [Phobos' "blacklist" trace filtering](https://phobos.petabridge.com/articles/tracing/filtering.html#blacklist-filtering), which is built for the purpose of decomposing large streams into smaller ones. However, given that all of the message content is pretty much identical in this sample that wouldn't be easy to do.

I hope this helps!